### PR TITLE
allow serial debug disable, see #4

### DIFF
--- a/ESP32-HUB75-MatrixPanel-DMA-config.h
+++ b/ESP32-HUB75-MatrixPanel-DMA-config.h
@@ -4,7 +4,9 @@
 #include "ESP32-HUB75-MatrixPanel-DMA-types.h"
 
 //сообщения отладки по UART
-#define SERIAL_DEBUG
+#ifndef DISABLE_SERIAL_DEBUG
+  #define SERIAL_DEBUG
+#endif  
 //прроцедуры инциализации регистров драйверов чрезе прямой доступ к выводам интерфейса 
 //оставлено на всякий случай
 //#define DIRECT_DRIVER_INIT

--- a/ESP32-HUB75-MatrixPanel-DMA-icn2053.cpp
+++ b/ESP32-HUB75-MatrixPanel-DMA-icn2053.cpp
@@ -2,7 +2,9 @@
 #include "ESP32-HUB75-MatrixPanel-DMA-icn2053.h"
 #include "ESP32-HUB75-MatrixPanel-DMA-leddrivers.h"
 
-#define SERIAL_DEBUG
+#ifndef DISABLE_SERIAL_DEBUG
+  #define SERIAL_DEBUG
+#endif 
 
 #define offset_prefix  dma_buff.all_row_data_cnt
 #define offset_suffix  (dma_buff.all_row_data_cnt + dma_buff.frame_prefix_cnt)
@@ -874,8 +876,10 @@ bool MatrixPanel_DMA::begin()
   setRotation(0);
   setMirrorX(false);
   setMirrorY(false);
+  #ifdef SERIAL_DEBUG  
   Serial.println(mirror_x);
   Serial.println(mirror_y);
+  #endif
 
   /* As DMA buffers are dynamically allocated, we must allocated in begin()
   * Ref: https://github.com/espressif/arduino-esp32/issues/831

--- a/library.json
+++ b/library.json
@@ -1,0 +1,4 @@
+{
+  "name": "ESP32-HUB75-MatrixPanel-DMA-ICN2053",
+  "version": "0.0.0+20230610211840"
+}


### PR DESCRIPTION
This code change allows to disable serial debug.
With PlatformIO by example using
build_flags =
    -DDISABLE_SERIAL_DEBUG=1
in .ini file.

It also embeds the two not controlled serial messages:
  Serial.println(mirror_x);
  Serial.println(mirror_y);